### PR TITLE
feat: add configurable spark configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .bsp
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SparkTest - 0.1.0
+# SparkTest - 0.2.0
 
 **SparkTest** is a Scala library for unit testing with [Spark](https://github.com/apache/spark). 
 For now, it is only made for DataFrames. 
@@ -56,7 +56,7 @@ To use **SparkTest** in an existing maven or sbt project:
 <dependency>
   <groupId>com.bedrockstreaming</groupId>
   <artifactId>sparktest_2.12</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -64,12 +64,13 @@ To use **SparkTest** in an existing maven or sbt project:
 ### SBT
 
 ```scala
-libraryDependencies += "com.bedrockstreaming" % "sparktest_2.12" % "0.1.0" % "test"
+libraryDependencies += "com.bedrockstreaming" % "sparktest_2.12" % "0.2.0" % "test"
 ```
 
 ## Tools
 ### SparkTestSupport
 This small `trait` provides a simple SparkSession with log set to warnings and let you focus only on your tests and not on the technical needs to create them.
+If your SparkSession need additional configuration, you can pass it through the val `additionalSparkConfiguration`.
 
 Example:
 ```scala
@@ -83,8 +84,12 @@ class MainSpec
   with Matchers
   with SparkTestSupport {
 
+  override lazy val additionalSparkConfiguration: Map[String, String] =
+    Map("spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",
+      "spark.sql.catalog.spark_catalog" -> "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+
   "main" should "do stuff" in {
-    # A SparkSession `spark` is built in trait `SparkTestSupport`
+    // A SparkSession `spark` is built in trait `SparkTestSupport`
     import spark.implicits._
     
     // ...
@@ -110,7 +115,7 @@ class MainSpec
   with SparkTestSupport {
 
   "main" should "do stuff" in {
-    # A SparkSession `spark` is built in trait `SparkTestSupport`
+    // A SparkSession `spark` is built in trait `SparkTestSupport`
     import spark.implicits._
     
     val df1 = Seq(("id1", 42)).toDF("id", "age")

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.bedrockstreaming"
-ThisBuild / version := "0.1.0"
+ThisBuild / version := "0.2.0"
 ThisBuild / scalaVersion := "2.12.11"
 
 // ********

--- a/src/main/scala/com/bedrockstreaming/data/sparktest/SparkTestSupport.scala
+++ b/src/main/scala/com/bedrockstreaming/data/sparktest/SparkTestSupport.scala
@@ -16,7 +16,7 @@ trait SparkTestSupport {
     .appName(appName)
     .config("spark.sql.shuffle.partitions", shufflePartitions.toString)
 
-  additionalSparkConfiguration.foreach {case (k, v) => sparkBuilder.config(k, v)}
+  additionalSparkConfiguration.foreach { case (k, v) => sparkBuilder.config(k, v) }
 
   implicit val spark: SparkSession = sparkBuilder.getOrCreate()
 

--- a/src/main/scala/com/bedrockstreaming/data/sparktest/SparkTestSupport.scala
+++ b/src/main/scala/com/bedrockstreaming/data/sparktest/SparkTestSupport.scala
@@ -8,13 +8,17 @@ trait SparkTestSupport {
   lazy val appName: String = "SparkTest Session"
   lazy val logLevel: Level = Level.WARN
   lazy val shufflePartitions: Int = 2
+  lazy val additionalSparkConfiguration: Map[String, String] = Map()
 
-  implicit val spark: SparkSession = SparkSession
+  private val sparkBuilder = SparkSession
     .builder()
     .master("local[*]")
     .appName(appName)
     .config("spark.sql.shuffle.partitions", shufflePartitions.toString)
-    .getOrCreate()
+
+  additionalSparkConfiguration.foreach {case (k, v) => sparkBuilder.config(k, v)}
+
+  implicit val spark: SparkSession = sparkBuilder.getOrCreate()
 
   spark.sparkContext.setLogLevel(logLevel.name())
 }

--- a/src/test/scala/com/bedrockstreaming/data/sparktest/SparkTestSupportSpec.scala
+++ b/src/test/scala/com/bedrockstreaming/data/sparktest/SparkTestSupportSpec.scala
@@ -1,0 +1,17 @@
+package com.bedrockstreaming.data.sparktest
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SparkTestSupportSpec extends AnyFlatSpec with Matchers with SparkTestSupport {
+
+  override lazy val additionalSparkConfiguration: Map[String, String] =
+    Map("spark.test.toto" -> "false", "spark.test.titi" -> "0")
+
+  "spark" should "possess passed additional configuration" in {
+    val sparkConf = spark.conf.getAll
+    sparkConf.contains("spark.test.toto") shouldBe true
+    sparkConf.contains("spark.test.titi") shouldBe true
+    sparkConf.contains("spark.test.tata") shouldBe false
+  }
+}


### PR DESCRIPTION
## Why?
<!-- Explain the purpose of your modifications -->
Add a way to add custom configuration during the creation of the test SparkSession.

## How?
<!-- Explain in few words your solution choices to help your team mates "enter" the code -->
Add a Map `additionalSparkConfiguration` that can be overridden when using SparkTestSupport trait.
