### PR TITLE
Remove runtime call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SparkTest - 0.2.0
+# SparkTest - 0.3.0
 
 **SparkTest** is a Scala library for unit testing with [Spark](https://github.com/apache/spark). 
 For now, it is only made for DataFrames. 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "com.bedrockstreaming"
-ThisBuild / version := "0.2.0"
+ThisBuild / version := "0.3.0"
 ThisBuild / scalaVersion := "2.12.11"
 
 // ********

--- a/src/main/scala/com/bedrockstreaming/data/sparktest/CustomPrettifier.scala
+++ b/src/main/scala/com/bedrockstreaming/data/sparktest/CustomPrettifier.scala
@@ -1,11 +1,9 @@
 package com.bedrockstreaming.data.sparktest
 
-import org.apache.spark.sql.DataFrame
+import com.bedrockstreaming.data.sparktest.CustomPrettifier.prettyDataFrame
 import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.{ DataFrame, SparkShowString }
 import org.scalactic.Prettifier
-import java.lang.reflect.Method
-
-import CustomPrettifier.prettyDataFrame
 
 trait CustomPrettifier {
 
@@ -48,13 +46,6 @@ object CustomPrettifier {
     numRows: Int = Int.MaxValue,
     truncate: Int = 0,
     vertical: Boolean = false
-  ): String = {
-    val methodName = "showString"
-    val method: Method =
-      df.getClass.getDeclaredMethod(methodName, numRows.getClass, truncate.getClass, vertical.getClass)
-    method.setAccessible(true)
-    method
-      .invoke(df, numRows.asInstanceOf[Object], truncate.asInstanceOf[Object], vertical.asInstanceOf[Object])
-      .asInstanceOf[String]
-  }
+  ): String =
+    SparkShowString(df, numRows, truncate, vertical)
 }

--- a/src/main/scala/com/bedrockstreaming/data/sparktest/CustomPrettifier.scala
+++ b/src/main/scala/com/bedrockstreaming/data/sparktest/CustomPrettifier.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.functions.col
 import org.scalactic.Prettifier
 import java.lang.reflect.Method
 
-import CustomerPrettifier.prettyDataFrame
+import CustomPrettifier.prettyDataFrame
 
 trait CustomPrettifier {
 
@@ -15,7 +15,7 @@ trait CustomPrettifier {
   }
 }
 
-object CustomerPrettifier {
+object CustomPrettifier {
 
   private[sparktest] def prettyDataFrame(df: DataFrame): String = {
     val schemaTitle =

--- a/src/main/scala/org/apache/spark/sql/SparkShowString.scala
+++ b/src/main/scala/org/apache/spark/sql/SparkShowString.scala
@@ -1,0 +1,7 @@
+package org.apache.spark.sql
+
+object SparkShowString {
+
+  def apply(df: DataFrame, numRows: Int = Int.MaxValue, truncate: Int = 0, vertical: Boolean = false): String =
+    df.showString(numRows, truncate, vertical)
+}

--- a/src/test/scala/com/bedrockstreaming/data/sparktest/CustomPrettifierSpec.scala
+++ b/src/test/scala/com/bedrockstreaming/data/sparktest/CustomPrettifierSpec.scala
@@ -1,6 +1,6 @@
 package com.bedrockstreaming.data.sparktest
 
-import com.bedrockstreaming.data.sparktest.CustomerPrettifier.prettyDataFrame
+import com.bedrockstreaming.data.sparktest.CustomPrettifier.prettyDataFrame
 import com.bedrockstreaming.data.sparktest.SparkTestTools.SparkSessionOps
 import org.apache.spark.sql.types.{ IntegerType, LongType, StringType }
 import org.scalatest.flatspec.AnyFlatSpec


### PR DESCRIPTION
## Why?
Remove runtime call to `org.apache.spark.sql.Dataset#showString`

## How?
Create an object in package `org.apache.spark.sql` to access `org.apache.spark.sql.Dataset#showString` private method
